### PR TITLE
Add ShopSavvy

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ See <https://xyhp915.github.io/logseq-marketplace-table/> and filter to `Themes`
 - [logseq-plugin-ai-query](https://github.com/dailydaniel/logseq-plugin-ai-query) - AI generation of advanced queries
 - [logseq-plugin-copilot](https://github.com/chhabrakadabra/logseq-plugin-copilot) by chhabrakadabra - Talk to AI about your Logseq notes.
 - [logseq-insert-random-pages](https://github.com/wonyoung-jang/logseq-insert-random-pages) by Wonyoung Jang - Insert random pages as blocks.
+- [logseq-shopsavvy](https://github.com/shopsavvy/logseq-shopsavvy) by ShopSavvy - Look up product prices and insert comparison cards into your graph
 
 See <https://xyhp915.github.io/logseq-marketplace-table/> and filter to `Plugins` for a full list
 


### PR DESCRIPTION
Add [logseq-shopsavvy](https://github.com/shopsavvy/logseq-shopsavvy) to the Plugins section. Logseq plugin for looking up product prices and inserting comparison cards into your graph.