### PR TITLE
Add llm-wiki to Workflows and Innovations

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ These are integrations that are officially supported by the third party:
 - [save-to-logseq](https://chromewebstore.google.com/detail/send-to-logseq/mgdccnefjlmhnfbmlnhddoogimbpmilj) By yutaodou - Web clipper extension for Logseq. Send page, selection text, page link, images, twitter, YouTube video to Logseq via Logseq HTTPs API server.
 - [logseq-mass-pages-recovery](https://github.com/jmbenedetto/logseq_mass_pages_recovery.git) by JMB - Jupyther notebook writen in python to undo mass pages changes as the ones done through VS Code. It leverages LogSeq backup in logseq/bak dir within LogSeq local graph.
 - [Logseq Advanced Query Builder](https://adxsoft.github.io/logseqadvancedquerybuilder/) by adxsoft - An Experimental online tool to help Logseq Users build advanced queries from simple commands
+- [llm-wiki](https://github.com/MehmetGoekce/llm-wiki) by MehmetGoekce - Maintain your Logseq graph automatically with Claude Code. Implements [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) with five operations (`/wiki ingest`, `query`, `lint`, `status`, `migrate`), schema-driven consistency, and automated health checks (orphans, stale pages, broken refs, credential leaks). Two-layer cache architecture (auto-loaded rules + on-demand wiki).
 
 ### Bibliography and PDF Integrations
 Bibliography managers (eg Zotero) are widely used in scientific research, and scientist often need to read PDFs and take in-depth notes.


### PR DESCRIPTION
## Summary

Adds [llm-wiki](https://github.com/MehmetGoekce/llm-wiki) to the **Workflows and Innovations** section. It is a Logseq-based implementation of [Andrej Karpathy's LLM Wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) — Claude Code maintains the graph for you (ingest sources, query, lint, status), with schema-driven consistency and a two-layer cache architecture.

## Why it fits

The "Workflows and Innovations" section already lists tools that automate parts of Logseq maintenance (Lupin, logseq-doctor, Logseq Advanced Query Builder, etc.). llm-wiki extends this idea further: it lets an LLM **maintain the entire knowledge graph** — extracting facts from new sources, updating cross-references, enforcing the schema, and running health checks (orphans, stale pages, broken refs, credential leaks).

The Logseq outliner format is what makes the LLM use case work — every block is independently addressable, so an ingest can append new content without disrupting existing structure. This is genuinely Logseq-native; the same pattern is much harder in flat-markdown systems.

## Project details

- **License:** MIT
- **Status:** Active (~65★, last commit ~1 week ago)
- **Tech stack:** Claude Code + Logseq (Obsidian also supported, but Logseq is the recommended/primary target)
- **Standalone:** No Logseq plugin, no Logseq HTTP API dependency — operates directly on the markdown files

## Test plan

- [x] Entry follows the section's existing one-line format ("by Author - Description")
- [x] Repo URL resolves and is publicly accessible
- [x] Description honestly reflects the project (no hype)
- [x] Section choice (Workflows and Innovations) matches existing similar entries